### PR TITLE
Added Watchdog timer

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -358,7 +358,7 @@ namespace MagneticNavigation {
                     zeroAllMagnets();
                     levelIndicatorLEDs.clear();
                     const timeoutColor = neopixel.rgb(255, 0, 255); // pink
-                    while(!watchdog.get_running() && watchdog !== undefined){
+                    while(!this.running && input.runningTime() - startTime >= this.timeout){
                         levelIndicatorLEDs.showColor(timeoutColor);
                         basic.pause(250)
                         levelIndicatorLEDs.clear();

--- a/main.ts
+++ b/main.ts
@@ -368,7 +368,7 @@ namespace MagneticNavigation {
         }
     }
 
-    export const watchdog = new Watchdog(3000); /* TODO: adjust timeout to 5min when done with testing */ 
+    export const watchdog = new Watchdog(5*60*1000); /*Timeout after 5 minutes */
 
     function resetI2CDevices(){
         let reset_pin = DigitalPin.P1;

--- a/main.ts
+++ b/main.ts
@@ -365,15 +365,13 @@ namespace MagneticNavigation {
         // Restart service, log error, etc.
         zeroAllMagnets();
         levelIndicatorLEDs.clear();
-        control.inBackground(() => {
-            const timeoutColor = neopixel.rgb(255, 0, 255); // pink
-            while(!watchdog.get_running()){
-                levelIndicatorLEDs.showColor(timeoutColor);
-                basic.pause(250)
-                levelIndicatorLEDs.clear();
-                basic.pause(250)
-            }
-        });
+        const timeoutColor = neopixel.rgb(255, 0, 255); // pink
+        while(!watchdog.get_running()){
+            levelIndicatorLEDs.showColor(timeoutColor);
+            basic.pause(250)
+            levelIndicatorLEDs.clear();
+            basic.pause(250)
+        }
     });
 
     watchdog.start();

--- a/main.ts
+++ b/main.ts
@@ -360,7 +360,7 @@ namespace MagneticNavigation {
         }
     }
 
-    const watchdog = new Watchdog(WatchdogTimeoutMS, () => {
+    export let watchdog = new Watchdog(WatchdogTimeoutMS, () => {
         console.log("Watchdog timeout! Shutting down motors");
         // Restart service, log error, etc.
         zeroAllMagnets();

--- a/main.ts
+++ b/main.ts
@@ -328,12 +328,14 @@ namespace MagneticNavigation {
         }
 
         start(): void {
+            if (this.running) return;
             this.running = true;
             levelIndicatorLEDs.clear();
             this.monitor();
         }
 
         reset(): void {
+            if (!this.running) return; 
             this.running = false;
             this.start();
         }

--- a/main.ts
+++ b/main.ts
@@ -368,7 +368,7 @@ namespace MagneticNavigation {
         }
     }
 
-    const watchdog = new Watchdog(3000); /* TODO: adjust timeout to 5min when done with testing */ 
+    export const watchdog = new Watchdog(3000); /* TODO: adjust timeout to 5min when done with testing */ 
 
     function resetI2CDevices(){
         let reset_pin = DigitalPin.P1;
@@ -740,6 +740,7 @@ namespace nanoMedForLife {
      */
     //% weight=86 blockId=setMagneticField block="Elektromagnete mit Joystick steuern"
     export function setMagneticField() {
+        MagneticNavigation.watchdog.reset();
         winkel = handlebit.getAngle(magnetJoystick)
         auslenkung = handlebit.getDeflection(magnetJoystick)
         MagneticNavigation.zeroAllMagnets()


### PR DESCRIPTION
The watchdog timer prevents heating up coils when motor controllers are used programmatically in a for-loop. Shuts off coils after 5 minutes after  the first use of the block. sending heart beats resets the watchdog timer.